### PR TITLE
Update to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/jcsirot/rust-pgn-parser"
 name = "pgnparser"
 
 [dependencies]
-nom = "~0.3.0"
+nom = "~1.0.0"
 regex = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate regex;
 use std::str;
 use std::result::Result;
 use std::collections::hash_map::HashMap;
-use nom::{IResult, digit, multispace, is_alphanumeric};
+use nom::{IResult, ErrorKind, digit, multispace, is_alphanumeric};
 use nom::IResult::*;
 use nom::Err::*;
 use regex::Regex;
@@ -127,7 +127,7 @@ fn pawn_move(input:&[u8]) -> IResult<&[u8], HalfMove > {
                         promotion: cap.at(2).map(Piece::from_str)
                     });
     }
-    return Error(Position(0, input));
+    return Error(Position(ErrorKind::Custom(0), input));
 }
 
 fn pawn_capture(input:&[u8]) -> IResult<&[u8], HalfMove> {
@@ -154,7 +154,7 @@ fn pawn_capture(input:&[u8]) -> IResult<&[u8], HalfMove> {
                         promotion: cap.at(3).map(Piece::from_str)
                     });
     }
-    return Error(Position(0, input));
+    return Error(Position(ErrorKind::Custom(0), input));
 }
 
 fn piece_move(input:&[u8]) -> IResult<&[u8], HalfMove > {
@@ -182,7 +182,7 @@ fn piece_move(input:&[u8]) -> IResult<&[u8], HalfMove > {
                         promotion: None
                     });
     }
-    return Error(Position(0, input));
+    return Error(Position(ErrorKind::Custom(0), input));
 }
 
 named!(san<&[u8], HalfMove>,
@@ -191,8 +191,8 @@ named!(san<&[u8], HalfMove>,
                pawn_move |
                pawn_capture |
                piece_move |
-               tag!("O-O-O") =>  { |_| return HalfMove::QueensideCastling } |
-               tag!("O-O") => { |_| return HalfMove::KingsideCastling }
+               complete!(tag!("O-O-O")) =>  { |_| return HalfMove::QueensideCastling } |
+               complete!(tag!("O-O")) => { |_| return HalfMove::KingsideCastling }
            ) ~
            multispace,
            || s)


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to upgrade your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
